### PR TITLE
Disable CORS to Enable WebViewer

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,24 +2,29 @@
 <html>
   <head>
     <title>Basic WebViewer</title>
-    <script src="http://localhost:8080/WebViewer/lib/webviewer.min.js"></script>
+    <!--<script src="http://localhost:8080/WebViewer/lib/webviewer.min.js"></script>-->
+    <!--
+      This is a public CDN I've hosted WebViewer dependencies on, please feel
+      free to change it to any web server hosting WebViewer dependencies
+    -->
+    <script src="https://admiring-brown-c5533a.netlify.app/webviewer.min.js"></script>
   </head>
   
   <body>
     <div id='viewer' style='height: 400vh; width: 600vh'></div>
     <script>
       WebViewer({
-        path: 'http://localhost:8080/WebViewer/lib', // path to the PDFTron 'lib' folder on your server
-        licenseKey: 'Insert commercial license key here after purchase',
-        initialDoc: 'https://pdftron.s3.amazonaws.com/downloads/pl/webviewer-demo.pdf'
-    }, document.getElementById('viewer'))
-    .then(instance => {
-        instance.UI.setTheme('dark')
-    })
-    .catch(error => {
-      console.log("#### Error log")
-      console.log(error)
-    });
+        // path: "http://localhost:8080/WebViewer/lib/webviewer.min.js",
+        path: "https://admiring-brown-c5533a.netlify.app/",
+      }, document.getElementById('viewer'))
+      .then(instance => {
+          instance.UI.setTheme('dark');
+          instance.UI.loadDocument('https://pdftron.s3.amazonaws.com/downloads/pl/webviewer-demo.pdf');
+      })
+      .catch(error => {
+        console.log("#### Error log")
+        console.log(error)
+      });
     </script>
   </body>
 </html>

--- a/test.py
+++ b/test.py
@@ -175,7 +175,8 @@ class MainFrame(wx.Frame):
         window_info.SetAsChild(self.browser_panel.GetHandle(),
                                [0, 0, width, height])
         self.browser = cef.CreateBrowserSync(window_info,
-                                             url="file://C:\\Users\\diego\\Documents\\Highside\\PDFTron\\CEFPython example\\ceftron27\\index.html")
+                                             url="file://C:\\Users\\diego\\Documents\\Highside\\PDFTron\\CEFPython example\\ceftron27\\index.html",
+                                             settings={"web_security_disabled": True})
         self.browser.SetClientHandler(FocusHandler())
 
     def OnSetFocus(self, _):


### PR DESCRIPTION
`WebViewer` is inherently built to make [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) requests, which is using the `http`/`https` protocols, and the `Chromium Embedded Framework` seems to rely on the assumption that the `file://` protocol is being used.

In order to work around [`CORS`](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) restrictions, disable CORS.